### PR TITLE
Fix duplicated healthchecks - #135

### DIFF
--- a/src/Skoruba.Duende.IdentityServer.Admin.Api/Startup.cs
+++ b/src/Skoruba.Duende.IdentityServer.Admin.Api/Startup.cs
@@ -112,7 +112,7 @@ namespace Skoruba.Duende.IdentityServer.Admin.Api
 
             services.AddAuditEventLogging<AdminAuditLogDbContext, AuditLog>(Configuration);
 
-            services.AddIdSHealthChecks<IdentityServerConfigurationDbContext, IdentityServerPersistedGrantDbContext, AdminIdentityDbContext, AdminLogDbContext, AdminAuditLogDbContext, IdentityServerDataProtectionDbContext>(Configuration, adminApiConfiguration);
+            services.AddIdSHealthChecks<IdentityServerConfigurationDbContext, IdentityServerPersistedGrantDbContext, AdminIdentityDbContext, AdminLogDbContext, AdminAuditLogDbContext, IdentityServerDataProtectionDbContext, UserIdentity>(adminApiConfiguration);
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, AdminApiConfiguration adminApiConfiguration)

--- a/src/Skoruba.Duende.IdentityServer.Admin.UI/Helpers/DependencyInjection/AdminUIServiceCollectionExtensions.cs
+++ b/src/Skoruba.Duende.IdentityServer.Admin.UI/Helpers/DependencyInjection/AdminUIServiceCollectionExtensions.cs
@@ -190,7 +190,7 @@ namespace Skoruba.Duende.IdentityServer.Admin.UI.Helpers.DependencyInjection
             var healthChecksBuilder = options.HealthChecksBuilderFactory?.Invoke(services) ?? services.AddHealthChecks();
             healthChecksBuilder.AddIdSHealthChecks<TIdentityServerDbContext, TPersistedGrantDbContext,
                 TIdentityDbContext, TLogDbContext, TAuditLogDbContext,
-                TDataProtectionDbContext, TAuditLog>(options.Admin, options.ConnectionStrings, options.DatabaseProvider);
+                TDataProtectionDbContext, TAuditLog, TUser>(options.Admin);
 
             // Adds a startup filter for further middleware configuration.
             services.AddSingleton(options.Testing);

--- a/src/Skoruba.Duende.IdentityServer.STS.Identity/Startup.cs
+++ b/src/Skoruba.Duende.IdentityServer.STS.Identity/Startup.cs
@@ -54,7 +54,7 @@ namespace Skoruba.Duende.IdentityServer.STS.Identity
             // Add authorization policies for MVC
             RegisterAuthorization(services);
 
-            services.AddIdSHealthChecks<IdentityServerConfigurationDbContext, IdentityServerPersistedGrantDbContext, AdminIdentityDbContext, IdentityServerDataProtectionDbContext>(Configuration);
+            services.AddIdSHealthChecks<IdentityServerConfigurationDbContext, IdentityServerPersistedGrantDbContext, AdminIdentityDbContext, IdentityServerDataProtectionDbContext, UserIdentity>();
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)


### PR DESCRIPTION
- AddDbContextCheck by default checks to see if it can connect to the database `.CanConnectAsync()` you can also run a custom query against the context
- No longer need healthchecks per db provider
- Name is not required by default it does `nameof` on the type now making it refactor friendly